### PR TITLE
[FIX] Skipping potential error when move has been deleted

### DIFF
--- a/stock_request/models/stock_move_line.py
+++ b/stock_request/models/stock_move_line.py
@@ -39,7 +39,7 @@ class StockMoveLine(models.Model):
     def _action_done(self):
         res = super(StockMoveLine, self)._action_done()
         for ml in self.filtered(
-                lambda m: m.move_id.allocation_ids):
+                lambda m: m.exists() and m.move_id.allocation_ids):
             qty_done = ml.product_uom_id._compute_quantity(
                 ml.qty_done, ml.product_id.uom_id)
 


### PR DESCRIPTION
If a move was deleted on this line (https://github.com/brain-tec/odoo/blob/11.0/addons/stock/models/stock_move_line.py#L413), this line would lead to an error about the move was already deleted so we cannot iterate on that.

This fix allows to avoid this problem and working on the moves still existing on self.