### PR TITLE
[bt#8874] fixes company_id of locations

### DIFF
--- a/partner_location_auto_create/__manifest__.py
+++ b/partner_location_auto_create/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Partner Location Auto Create',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': 'brain-tec AG, Savoir-faire Linux,Odoo Community Association ('
               'OCA)',
     'category': 'Warehouse',

--- a/partner_location_auto_create/migrations/11.0.1.0.1/pre-migration.py
+++ b/partner_location_auto_create/migrations/11.0.1.0.1/pre-migration.py
@@ -1,0 +1,5 @@
+def migrate(cr, version):
+    """remove company id fromm all locations of type supplier/vendor"""
+    cr.execute("""
+        update stock_location set company_id=Null where usage in ('supplier','customer');
+    """)

--- a/partner_location_auto_create/models/res_partner.py
+++ b/partner_location_auto_create/models/res_partner.py
@@ -78,7 +78,7 @@ class ResPartner(models.Model):
             'name': self.name,
             'usage': usage,
             'partner_id': self.id,
-            'company_id': self.company_id.id,
+            'company_id': False,
             'location_id': parent.id,
             'main_partner_location': True,
         })


### PR DESCRIPTION
also fixes wrong stock valuation report.
Odoos assumption is, that incoming Moves don't have a source location
and outgoing ones don't have a dest location. When looking up these
moves they missed in the stock valuation report due to wrongly set
company id on the customer/vendor locations

Important: Please Update the projects submodule after merging this PR

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=8874">[bt#8874] PRIO 8: Inventory Valuation Report</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>partner_location_auto_create</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->